### PR TITLE
update raytracing buffer calculation

### DIFF
--- a/tools/RAiDER/cli/raider.py
+++ b/tools/RAiDER/cli/raider.py
@@ -205,15 +205,15 @@ def calcDelays(iargs=None):
     los = params['los']
     aoi = params['aoi']
     model = params['weather_model']
-    # check projection
-    aoi.check_projection(model)
 
     # add a small buffer
-    aoi.add_buffer(model)
+    aoi.add_buffer(buffer = 1.5 * model.getLLRes())
 
     # add a buffer determined by latitude for ray tracing
-    wm_bounds = aoi.calc_buffer_ray(model) if los.ray_trace else aoi.bounds()
-
+    if los.ray_trace():
+        wm_bounds = aoi.calc_buffer_ray(los.getSensorDirection(), lookDir=los.getLookDirection(), incAngle=30)
+    else:
+        wm_bounds = aoi.bounds()
 
     wet_filenames = []
     for t, w, f in zip(

--- a/tools/RAiDER/losreader.py
+++ b/tools/RAiDER/losreader.py
@@ -181,6 +181,7 @@ class Raytracing(LOS):
         self._time = time
         self._pad  = pad
         self._convention = los_convention
+        self._orbit = None
         if self._convention.lower() != 'isce':
             raise NotImplementedError()
 
@@ -197,6 +198,23 @@ class Raytracing(LOS):
             self._look_dir = isce.core.LookSide.Left
         else:
             raise RuntimeError(f"Unknown look direction: {look_dir}")
+    
+
+    def getSensorDirection(self):
+        if self._orbit is None:
+            raise ValueError('The orbit has not been set')
+        z = self._orbit.position[:,2]
+        t = self._orbit.time
+        start = np.argmin(t)
+        end = np.argmax(t)
+        if z[start] > z[end]:
+            return 'desc'
+        else:
+            return 'asc'
+    
+
+    def getLookDirection(self):
+        return self._look_dir
 
     # Called in checkArgs
     def setTime(self, time, pad=600):

--- a/tools/RAiDER/models/weatherModel.py
+++ b/tools/RAiDER/models/weatherModel.py
@@ -138,6 +138,10 @@ class WeatherModel(ABC):
 
     def dtime(self):
         return self._time_res
+    
+
+    def getLLRes(self):
+        return np.max([self._lat_res, self._lon_res])
 
 
     def fetch(self, out, ll_bounds, time):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- updated the simple buffer to not truncate on -180/180, assume(d) that this should be handled elsewhere
- updated calc_buffer_ray to: 
  - only use lat/lon by scaling based on latitude
  - Only buffer on the side nearest the sensor using orbit direction and look side, both of which are now instantiated with the raytracing object. This will help minimize buffer bounds going outside valid regions
- Added the relevant methods to the AOI and WeatherModel objects